### PR TITLE
Updated the deploy mocks

### DIFF
--- a/deploy/00-deploy-mocks.js
+++ b/deploy/00-deploy-mocks.js
@@ -13,10 +13,10 @@ module.exports = async function ({ getNamedAccounts, deployments }) {
     if (developmentChains.includes(network.name)) {
         log("Local network detected! Deploying mocks...");
         // deploy a mock vrfcoordinator..
-        await deploy("MockV3Aggregator", {
+        await deploy("VRFCoordinatorV2Mock", {
             from: deployer,
-            log: true,
-            args: [DECIMALS, INITIAL_PRICE],
+            args: [BASE_FEE, GAS_PRICE_LINK],
+            log: true
         });
         log("Mocks Deployed!");
         log("---------------------------------------------------------");


### PR DESCRIPTION
Just saw your discussion, it was wild!

You have the wrong contract my friend, You have to deploy `VRFCoordinatorV2Mock` contract but instead you were deploying `MockV3Aggregator` one,

That's why the error was coming that : _couldn't find the artifacts!_

I was busy elsewhere that's the reason for this late assist!

Merge this PR! It will solve your current error!